### PR TITLE
Added per cell implementation (#38) and partial performance enhancement (#39)

### DIFF
--- a/templates/app_api_template.py
+++ b/templates/app_api_template.py
@@ -57,14 +57,20 @@ def get_results(notebook_name: str, request: Request):
             return JSONResponse(content=result)
     except Exception as e:
         raise APIException(
-            f"An error occured while exporting the [{notebook_name}] notebook.",
+            f"An error occured while executing the [{notebook_name}] notebook.",
             str(e)
         )
 
 @app.get("/api/notebooks/{notebook_name}/cells/{cell_index}/execute", summary="Executes a notebook's cell")
 def get_cell_results(notebook_name: str, cell_index:int, request: Request):
-    file_path = get_notebook_file_path(notebook_name)
-    return CONVERTER.convert_notebook_cell_to_json(file_path, cell_index)
+    try:
+        file_path = get_notebook_file_path(notebook_name)
+        return CONVERTER.convert_notebook_cell_to_json(file_path, cell_index)
+    except Exception as e:
+        raise APIException(
+            f"An error occured while executing the [{cell_index}] cell of [{notebook_name}] notebook.",
+            str(e)
+        )
 
 @app.get("/api/version")
 def version():

--- a/templates/notebook_converter.py
+++ b/templates/notebook_converter.py
@@ -25,6 +25,11 @@ class NotebookConverter(Preprocessor):
         with open(path, "r", encoding="utf-8") as f:
             return nbformat.read(f, as_version=4)
 
+    def check_index_validity(self, cell_index: int, notebook: nbformat.NotebookNode):
+        notebook_cells_length = len(notebook.cells)
+        if cell_index < 0 or cell_index >= notebook_cells_length:
+            raise IndexError(f"Cell index [{cell_index}] is out of bounds. This notebook consists of [{notebook_cells_length - 1}] cells.")
+
     def execute(self, file_path: Path) -> tuple[nbformat.NotebookNode, Path]:
         out_path = self.get_executed_file_path(file_path)
 
@@ -42,9 +47,11 @@ class NotebookConverter(Preprocessor):
 
         if out_path.is_file():
             executed_np = self.read_notebook(out_path)
+            self.check_index_validity(cell_index, executed_np)
             return executed_np.cells[cell_index]
         else:
             notebook_content = self.read_notebook(file_path)
+            self.check_index_validity(cell_index, notebook_content)
             notebook_cell = notebook_content.cells[cell_index]
             client = nbclient.NotebookClient(notebook_content, kernel_name="python3")
 


### PR DESCRIPTION
This commit consists of:
- Change of endpoint from `/api/notebooks/{notebook_name}/export` to `/api/notebooks/{notebook_name}/execute`
- Added new endpoint for per cell execution `/api/notebooks/{notebook_name}/cells/{cell_index}/execute`
- Added performance enhancement : when we execute a notebook once, we store the result to use it on future executions. The same methodology applies when we want to execute a cell. We simply get the stored notebook with the results and we get the specified cell.